### PR TITLE
cd4analysis!55 Modify configtemplate parameters

### DIFF
--- a/generators/cd2pojo/main/resources/cd2pojo/init/CD2Java.ftl
+++ b/generators/cd2pojo/main/resources/cd2pojo/init/CD2Java.ftl
@@ -6,11 +6,11 @@
   the '-ct' CLI argument), make sure it stays compatible with MontiArc, e.g., by
   applying the same decorators as this template does.
 -->
-${tc.signature("glex", "deConf")}
 <#-- @ftlvariable name="glex" type="de.monticore.generating.templateengine.GlobalExtensionManagement" -->
-<#-- @ftlvariable name="deConf" type="de.monticore.cd.codegen.DecoratorConfig" -->
+<#-- @ftlvariable name="decConfig" type="de.monticore.cd.codegen.DecoratorConfig" -->
 <#-- @ftlvariable name="tc" type="de.monticore.generating.templateengine.TemplateController" -->
+<#-- @ftlvariable name="genSetup" type="de.monticore.generating.GeneratorSetup" -->
 
 ${glex.replaceTemplate("cd2java.EmptyBody", glex.templateHP("cd2pojo.EmptyBody.ftl"))}
 
-${deConf.withCopyCreator().defaultApply()}
+${decConfig.withCopyCreator().defaultApply()}


### PR DESCRIPTION
Breaking change in [cd4a!55](https://github.com/MontiCore/cd4analysis/pull/55) to avoid future breaking changes (ironic, isn't it?)